### PR TITLE
Extend listing functionality + Added twig function

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -15,3 +15,8 @@ ignore:
 
 ## ignore listing templates
 #ignore_listing: true
+
+## when ignore_listing is not = true: listings templates may not exist yet may contain child pages.
+## add path will keep listing visible in tree but remove its link.
+#remove_link:
+#  - /pages

--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -34,6 +34,17 @@ class SitemapExtension extends SimpleExtension
     }
 
     /**
+     * Twig function returns sitemap.
+     *
+     * @return Response
+     */
+    protected function registerTwigFunctions(){
+        return [
+            'sitemapEntries' => 'twigGetLinks'
+        ];
+    }
+
+    /**
      * Route for XML based sitemap.
      *
      * @return Response
@@ -93,8 +104,13 @@ class SitemapExtension extends SimpleExtension
         return [
             'ignore'             => [],
             'ignore_contenttype' => [],
+            'remove_link' => [],
             'ignore_listing'     => false,
         ];
+    }
+
+    public function twigGetLinks(){
+        return $this->getLinks();
     }
 
     /**
@@ -120,19 +136,29 @@ class SitemapExtension extends SimpleExtension
                 'title' => $app['config']->get('general/sitename'),
             ],
         ];
+
         foreach ($contentTypes as $contentType) {
             $searchable = (isset($contentType['searchable']) && $contentType['searchable']) || !isset($contentType['searchable']);
             $isIgnored = in_array($contentType['slug'], $config['ignore_contenttype']);
+            $isIgnoredURL = in_array('/' . $contentType['slug'], $config['remove_link']);
 
             if (!$isIgnored && !$contentType['viewless'] && $searchable) {
                 $baseDepth = 0;
                 if (!$config['ignore_listing']) {
                     $baseDepth = 1;
-                    $links[] = [
-                        'link'  => $rootPath . $contentType['slug'],
-                        'title' => $contentType['name'],
-                        'depth' => 1,
-                    ];
+                    if ($isIgnoredURL){
+                        $links[] = [
+                            'link'  => '',
+                            'title' => $contentType['name'],
+                            'depth' => 1,
+                        ];
+                    }else{
+                        $links[] = [
+                            'link'  => $rootPath . $contentType['slug'],
+                            'title' => $contentType['name'],
+                            'depth' => 1,
+                        ];
+                    }
                 }
                 $content = $app['storage']->getContent($contentType['slug'], $contentParams);
                 /** @var Content $entry */

--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -104,7 +104,7 @@ class SitemapExtension extends SimpleExtension
         return [
             'ignore'             => [],
             'ignore_contenttype' => [],
-            'remove_link' => [],
+            'remove_link'        => [],
             'ignore_listing'     => false,
         ];
     }

--- a/templates/_sitemap_list.twig
+++ b/templates/_sitemap_list.twig
@@ -1,23 +1,28 @@
 <ul>
-{% set depth = 1 %}
-{% for entry in entries %}
-    {% if entry.link is defined %}
-        {% if entry.depth is defined and entry.depth > depth %}
-            <ul>
+    {% set depth = 1 %}
+    {% for entry in entries %}
+        {% if entry.link is defined %}
+            {% if entry.depth is defined and entry.depth > depth %}
+                <ul>
+            {% endif %}
+            {% if entry.depth is defined and entry.depth < depth %}
+                </ul>
+            {% endif %}
+            <li>
+                {% if entry.link is not empty %}
+                    <a href="{{ entry.link }}">{{ entry.title }}</a>
+                {% else %}
+                    <span>{{ entry.title }}</span>
+                {% endif %}
+            </li>
+            {% if entry.depth is defined %}
+                {% set depth = entry.depth %}
+            {% else %}
+                {% set depth = 1 %}
+            {% endif %}
         {% endif %}
-        {% if entry.depth is defined and entry.depth < depth %}
-            </ul>
-        {% endif %}
-        <li><a href="{{ entry.link }}">{{ entry.title }}</a></li>
-
-        {% if entry.depth is defined %}
-            {% set depth = entry.depth %}
-        {% else %}
-            {% set depth = 1 %}
-        {% endif %}
-    {% endif %}
-{% endfor %}
-{% if depth > 1 %}
-    </ul>
+    {% endfor %}
+    {% if depth > 1 %}
+</ul>
 {% endif %}
 </ul>

--- a/templates/sitemap_xml.twig
+++ b/templates/sitemap_xml.twig
@@ -2,51 +2,53 @@
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for entry in entries %}
         {% if entry.link is defined %}
-            <url>
-                <loc>{{ app.paths.hosturl }}{{ entry.link }}</loc>
-                {% if entry.link == "/" %}
-                    {% setcontent record = app.config.get('general/homepage') returnsingle %}
-                {% elseif entry.record is defined %}
-                    {% set record = entry.record %}
-                {% endif %}
-                {% if record.datechanged is defined %}
-                    <lastmod>{{ record.datechanged|date('Y-m-d\\TH:i:sP') }}</lastmod>
-                {% endif %}
-                <changefreq>weekly</changefreq>
-                {% if entry.link == "/" %}
-                    <priority>1</priority>
-                {% else %}
-                    <priority>0.8</priority>
-                {% endif %}
-                {% for key,value in record.values|default %}
-                    {% if record.fieldtype(key) == "image" and value != "" %}
-                        <image:image>
-                            <image:loc>{{ app.paths.hosturl }}{{ value|image(app.config.get('general/thumbnails/default_image')|first, app.config.get('general/thumbnails/default_image')|last) }}</image:loc>
-                            {% if value.alt|default() %}
-                                <image:title><![CDATA[{{ value.alt }}]]></image:title>
-                            {% endif %}
-                            {% if value.title|default() %}
-                                <image:caption><![CDATA[{{ value.title }}]]></image:caption>
-                            {% endif %}
-                        </image:image>
-                    {% elseif record.fieldtype(key) == "imagelist" and attribute(record, key) is not empty %}
-                        {% set list = attribute(record, key) %}
-                        {% for item in list %}
+            {% if entry.link is not empty %}
+                <url>
+                    <loc>{{ app.paths.hosturl }}{{ entry.link }}</loc>
+                    {% if entry.link == "/" %}
+                        {% setcontent record = app.config.get('general/homepage') returnsingle %}
+                    {% elseif entry.record is defined %}
+                        {% set record = entry.record %}
+                    {% endif %}
+                    {% if record.datechanged is defined %}
+                        <lastmod>{{ record.datechanged|date('Y-m-d\\TH:i:sP') }}</lastmod>
+                    {% endif %}
+                    <changefreq>weekly</changefreq>
+                    {% if entry.link == "/" %}
+                        <priority>1</priority>
+                    {% else %}
+                        <priority>0.8</priority>
+                    {% endif %}
+                    {% for key,value in record.values|default %}
+                        {% if record.fieldtype(key) == "image" and value != "" %}
                             <image:image>
-                                <image:loc>{{ app.paths.hosturl }}{{ item.filename|image(app.config.get('general/thumbnails/default_image')|first, app.config.get('general/thumbnails/default_image')|last) }}</image:loc>
-                                {% if item.title %}
-                                {% if item.alt|default() %}
-                                    <image:title><![CDATA[{{ item.alt }}]]></image:title>
+                                <image:loc>{{ app.paths.hosturl }}{{ value|image(app.config.get('general/thumbnails/default_image')|first, app.config.get('general/thumbnails/default_image')|last) }}</image:loc>
+                                {% if value.alt|default() %}
+                                    <image:title><![CDATA[{{ value.alt }}]]></image:title>
                                 {% endif %}
-                                {% if item.title|default() %}
-                                    <image:caption><![CDATA[{{ item.title }}]]></image:caption>
-                                {% endif %}
+                                {% if value.title|default() %}
+                                    <image:caption><![CDATA[{{ value.title }}]]></image:caption>
                                 {% endif %}
                             </image:image>
-                        {% endfor %}
-                    {% endif %}
-                {% endfor %}
-            </url>
+                        {% elseif record.fieldtype(key) == "imagelist" and attribute(record, key) is not empty %}
+                            {% set list = attribute(record, key) %}
+                            {% for item in list %}
+                                <image:image>
+                                    <image:loc>{{ app.paths.hosturl }}{{ item.filename|image(app.config.get('general/thumbnails/default_image')|first, app.config.get('general/thumbnails/default_image')|last) }}</image:loc>
+                                    {% if item.title %}
+                                        {% if item.alt|default() %}
+                                            <image:title><![CDATA[{{ item.alt }}]]></image:title>
+                                        {% endif %}
+                                        {% if item.title|default() %}
+                                            <image:caption><![CDATA[{{ item.title }}]]></image:caption>
+                                        {% endif %}
+                                    {% endif %}
+                                </image:image>
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                </url>
+            {% endif %}
         {% endif %}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
- added the ability to remove listing links via extension config
- can only be used when ignore_listing is set to false
- keeps listing element in tree structure but removes clickable link to page
- removes item from xml  
- added a twig function to return getLinks() function outside extension scope eg. theme directory 