### PR TITLE
Fix custom routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,22 @@ Apart from that, it's good pratice to also add the following line to your
 Obviously, you should replace 'example.org' with the domain name of your website.
 
 This extension adds a 'route' for `/sitemap.xml` and `/sitemap` by default, but it 
-has lower priority than user defined routes. 
-If you use the `pagebinding` in `routing.yml` (or anything similar like `/{slug}` ),
+has lower priority than user defined routes.
+
+If you want AnimalDesign/bolt-translate extension compatibily or 
+if you use the `pagebinding` in `routing.yml` (or anything similar like `/{slug}` ),
 you need to add the following _above_ that route:
 
 ```
-sitemapxml:
-  path: /sitemap.xml
-  defaults: { _controller: 'Bolt\Extension\Bolt\Sitemap\Extension::sitemapXml' }
-
-
 sitemap:
   path: /sitemap
-  defaults: { _controller: 'Bolt\Extension\Bolt\Sitemap\Extension::sitemap' }
+  defaults: { _controller: sitemap.controller:sitemap }
+
+sitemapXml:
+  path: /sitemap.xml
+  defaults: { _controller: sitemap.controller:sitemapXml }
 ```
+
 
 Note, if you have a ContentType with the property `searchable: false`, that content 
 type will be ignored.

--- a/src/Controller/Sitemap.php
+++ b/src/Controller/Sitemap.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Bolt\Extension\Bolt\Sitemap\Controller;
+
+use Silex\Application;
+use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The controller for Sitemap routes.
+ *
+ */
+
+class Sitemap implements ControllerProviderInterface
+{
+    /** @var Application */
+    protected $app;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function connect(Application $app)
+    {
+        $this->app = $app;
+
+        /** @var ControllerCollection $ctr */
+        $ctr = $app['controllers_factory'];
+
+        // This matches both GET requests.
+        $ctr->match('sitemap', [$this, 'sitemap'])
+            ->method('GET');
+
+        $ctr->match('sitemap.xml', [$this, 'sitemapXml'])
+            ->method('GET');
+
+        return $ctr;
+    }
+
+    /**
+     * @param Application $app
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function sitemap(Application $app, Request $request)
+    {
+        $config = $app['sitemap.config'];
+
+        $body = $app["twig"]->render($config['template'], ['entries' => $app['sitemap.links']]);
+
+        return new Response($body, Response::HTTP_OK);
+    }
+
+    /**
+     * @param Application $app
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function sitemapXml(Application $app, Request $request)
+    {
+        $config = $app['sitemap.config'];
+
+        $body = $app["twig"]->render($config['xml_template'], ['entries' => $app['sitemap.links']]);
+
+        $response = new Response($body, Response::HTTP_OK);
+        $response->headers->set('Content-Type', 'application/xml; charset=utf-8');
+
+        return $response;
+    }
+}

--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -66,7 +66,7 @@ class SitemapExtension extends SimpleExtension
             ->setCallback(function () {
                 $app = $this->getContainer();
                 $snippet = sprintf(
-                    '<link rel="sitemap" type="application/xml" title="Sitemap" href="%ssitemap.xml">',
+                    '<link rel="sitemap" type="application/xml" title="Sitemap" href="%s/sitemap.xml">',
                     $app['url_generator']->generate('homepage', [], UrlGeneratorInterface::ABSOLUTE_URL)
                 );
 

--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -154,7 +154,7 @@ class SitemapExtension extends SimpleExtension
                         ];
                     }else{
                         $links[] = [
-                            'link'  => $rootPath . $contentType['slug'],
+                            'link'  => $rootPath . '/' . $contentType['slug'],
                             'title' => $contentType['name'],
                             'depth' => 1,
                         ];


### PR DESCRIPTION
Custom routes didn't worked. I followed bolt doc to create controller callback classes : https://docs.bolt.cm/3.2/extensions/intermediate/controllers-routes#controller-callback-classes

So now, if you define you custom routes in routing.yml, sitemap works with AnimalDesign/bolt-translate extension. Enjoy !

Note I'm a PHP/Symfony/Bolt beginner, coding quality advices are welcome.