### PR TITLE
Allow to define routes for content type listings

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -13,6 +13,10 @@ ignore:
 #ignore_contenttype:
 #  - pages
 
+## listing routes (contenttype_slug: route_name)
+#listing_routes:
+#  pages: custom_pages_route
+
 ## ignore listing templates
 #ignore_listing: true
 

--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -159,7 +159,7 @@ class SitemapExtension extends SimpleExtension
                             'depth' => 1,
                         ];
                     } else {
-                        $link = $app['url_generator']->generate('contentlisting', ['contenttypeslug' => $contentType['slug']]);
+                        $link = $this->getListingLink($contentType['slug']);
                         $links[] = [
                             'link'  => $link,
                             'title' => $contentType['name'],
@@ -188,6 +188,25 @@ class SitemapExtension extends SimpleExtension
         }
 
         return $links;
+    }
+
+    /**
+     * @param string $contentTypeSlug
+     * @return string
+     */
+    private function getListingLink($contentTypeSlug)
+    {
+        $config = $this->getConfig();
+        $urlGenerator = $this->getContainer()['url_generator'];
+        $urlParameters = ['contenttypeslug' => $contentTypeSlug];
+
+        if(isset($config['listing_routes']) && isset($config['listing_routes'][$contentTypeSlug])) {
+            $routeName = $config['listing_routes'][$contentTypeSlug];
+
+            return $urlGenerator->generate($routeName, $urlParameters);
+        }
+
+        return $urlGenerator->generate('contentlisting', $urlParameters);
     }
 
     /**


### PR DESCRIPTION
Bolt doesn't support binding routes to content type listing, only binding to given records. It was a problem for me because this extension generated wrong paths (generic ones) and also the canonical address was wrong. It could make search bots to see the listings page twice (one time in menu, second time in sitemap).

This PR tries to address this problem by allowing to set listing of which content types should use which routes. Like this:

```yml
listing_routes:
  meetups: meetups_archive
  lectures: lectures_database
```