### PR TITLE
Add option to add links programmatically from extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ sitemapXml:
 Note, if you have a ContentType with the property `searchable: false`, that
 content type will be ignored.
 
+## Advanced links list control
+
+If you have your own bundled extension you can add, remove or change links
+before the sitemap is rendered. You need to subscribe to the 
+`SitemapEvents::AFTER_COLLECTING_LINKS` event. The object you will get is
+an instance of `SitemapEvent` class which has a `getLinks` method that returns 
+a `MutableBag` object. The last one is an array-like list of links. See example:
+
+```php
+protected function subscribe($dispatcher)
+{
+    $dispatcher->addListener(SitemapEvents::AFTER_COLLECTING_LINKS,
+        function ($event) {
+            /** @var SitemapEvent $event */
+            $links = $event->getLinks();
+            $links->add([
+                'link'  => '/lorem-ipsum',
+                'title' => 'Hello World!',
+                'depth' => 1,
+            ]);
+        }
+    );
+}
+```
+
 ## Sitemap stylesheets
 
 You can customize the sitemap with an xslt stylesheet if you copy the `templates/sitemap_xml.twig`

--- a/src/SitemapEvent.php
+++ b/src/SitemapEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bolt\Extension\Bolt\Sitemap;
+
+use Bolt\Collection\MutableBag;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class SitemapEvent extends GenericEvent
+{
+    /**
+     * @return MutableBag
+     */
+    public function getLinks()
+    {
+        return $this->subject;
+    }
+}

--- a/src/SitemapEvents.php
+++ b/src/SitemapEvents.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bolt\Extension\Bolt\Sitemap;
+
+/**
+ * Definitions for all possible SitemapEvents.
+ *
+ *  * @codeCoverageIgnore
+ */
+final class SitemapEvents
+{
+    private function __construct()
+    {
+    }
+
+    const AFTER_COLLECTING_LINKS = 'sitemapAfterCollectingLinks';
+}


### PR DESCRIPTION
I wanted to add some arbitrary links to the sitemap so I created this PR ;D

* The generated list of links is sent to functions that subscribe a special event
* I changed the array of links to be a mutable bag so it is easier to change the list (because objects, not like arrays, are passed by reference you don't need to manually update the list in event)
* I changed `$links[] = ...` to `$links->add(...` so people would see it isn't a normal array
* The subscribers can add, edit, or remove links
* I added a documentation in README.md of this new feature with an example

I tried to do the flow similarly to StorageEvent. I hope you like this addition.