### PR TITLE
sitemap.xml template - absolute_url

### DIFF
--- a/templates/sitemap_xml.twig
+++ b/templates/sitemap_xml.twig
@@ -4,7 +4,7 @@
         {% if entry.link is defined %}
             {% if entry.link is not empty %}
                 <url>
-                    <loc>{{ url('homepage')|trim('/', 'right') }}{{ entry.link }}</loc>
+                    <loc>{{ absolute_url(entry.link) }}</loc>
                     {% if entry.link == "/" %}
                         {% setcontent record = config.get('general/homepage') returnsingle %}
                     {% elseif entry.record is defined %}
@@ -22,7 +22,7 @@
                     {% for key,value in record.values|default if not ignore_images %}
                         {% if record.fieldtype(key) == "image" and value != "" %}
                             <image:image>
-                                <image:loc>{{ url('homepage')|trim('/', 'right') }}{{ value|image(config.get('general/thumbnails/default_image')|first, config.get('general/thumbnails/default_image')|last) }}</image:loc>
+                                <image:loc>{{ absolute_url(value|image(config.get('general/thumbnails/default_image')|first, config.get('general/thumbnails/default_image')|last)) }}</image:loc>
                                 {% if value.alt|default() %}
                                     <image:title><![CDATA[{{ value.alt }}]]></image:title>
                                 {% endif %}
@@ -34,7 +34,7 @@
                             {% set list = attribute(record, key) %}
                             {% for item in list %}
                                 <image:image>
-                                    <image:loc>{{ url('homepage')|trim('/', 'right') }}{{ item.filename|image(config.get('general/thumbnails/default_image')|first, config.get('general/thumbnails/default_image')|last) }}</image:loc>
+                                    <image:loc>{{ absolute_url(item.filename|image(config.get('general/thumbnails/default_image')|first, config.get('general/thumbnails/default_image')|last)) }}</image:loc>
                                     {% if item.title %}
                                         {% if item.alt|default() %}
                                             <image:title><![CDATA[{{ item.alt }}]]></image:title>


### PR DESCRIPTION
Using "absolute_url" instead of "url homepage" to generate valid links in sitemap.xml when used https://market.bolt.cm/view/animal/translate