### PR TITLE
Suppress errors/warnings when we can't set time limit and ini

### DIFF
--- a/src/SitemapExtension.php
+++ b/src/SitemapExtension.php
@@ -129,8 +129,8 @@ class SitemapExtension extends SimpleExtension
     private function getLinks()
     {
         // If we have a boatload of content, we might need a bit more memory.
-        set_time_limit(0);
-        ini_set('memory_limit', '512M');
+        @set_time_limit(0);
+        @ini_set('memory_limit', '512M');
 
         $app = $this->getContainer();
         $config = $this->getConfig();


### PR DESCRIPTION
Sometimes the hosting provider does not allow set_time_limit and ini_set, in those cases the extension should probably try anyway. and fail "naturally" if there is not enough memory or time rather than fail always because of trying to set those limits.