### PR TITLE
Generate correct URL:s when used with translate

### DIFF
--- a/templates/sitemap_xml.twig
+++ b/templates/sitemap_xml.twig
@@ -4,7 +4,7 @@
         {% if entry.link is defined %}
             {% if entry.link is not empty %}
                 <url>
-                    <loc>{{ url('homepage')|trim('/', 'right') }}{{ entry.link }}</loc>
+                    <loc>{{ absolute_url(entry.link) }}</loc>
                     {% if entry.link == "/" %}
                         {% setcontent record = config.get('general/homepage') returnsingle %}
                     {% elseif entry.record is defined %}


### PR DESCRIPTION
When translate is used the URL included the locale twice because it modifies the homepage route. This fixes that by using the absolute_url function instead.